### PR TITLE
Clarify policy distribution flow

### DIFF
--- a/cf-primer.md
+++ b/cf-primer.md
@@ -1,7 +1,7 @@
 % CF-Primer: Zero to Hero
 % Brian Bennett <bahamat@digitalelf.net>, @bahamat
-% 2013-04-13
   with Aleksey Tsalolikhin <aleksey@verticalsysadmin.com>, @atsaloli
+% 2017-10-20
 
 # Welcome!
 

--- a/cf-primer.md
+++ b/cf-primer.md
@@ -582,7 +582,7 @@ You can use the server's IP address instead of the DNS name.
 
 The policy files are distributed from `/var/cfengine/masterfiles` on the server (also known as the `policy_hub`).
 
-Clients copy policy files from `/var/cfengine/masterfiles` on the server to `/var/cfengine/inputs` on each host. CFEngine reads policy out of `/var/cfengine/inputs` when it runs (even on the server).
+Clients copy policy files from `/var/cfengine/masterfiles` on the server to `/var/cfengine/inputs`. CFEngine binaries read policy out of `/var/cfengine/inputs`.
 
 <div style="text-align:center">![](policy_propagation.png)</div>
 

--- a/cf-primer.md
+++ b/cf-primer.md
@@ -596,6 +596,8 @@ As you write new policies, each bundle needs to be listed in the `bundlesequence
 
 Bundles are executed in the order they are listed in the `bundlesequence`, but `inputs` can be listed in any order.
 
+Remember to make your changes in `/var/cfengine/masterfiles` on the server -- if you make them in `/var/cfengine/inputs`, they will get overwritten.
+
 # Keep Track of Promises Repaired and Promises Not Repaired
 
 CFEngine logs to `/var/cfengine/promise_summary.log`. Here's an example log message:

--- a/cf-primer.md
+++ b/cf-primer.md
@@ -1,7 +1,7 @@
 % CF-Primer: Zero to Hero
 % Brian Bennett <bahamat@digitalelf.net>, @bahamat
-  with Aleksey Tsalolikhin <aleksey@verticalsysadmin.com>
 % 2013-04-13
+  with Aleksey Tsalolikhin <aleksey@verticalsysadmin.com>, @atsaloli
 
 # Welcome!
 

--- a/cf-primer.md
+++ b/cf-primer.md
@@ -578,13 +578,17 @@ Simply run:
 
 You can use the server's IP address instead of the DNS name.
 
-# Managing and Distributing Policies
+# Distributing Policies
 
-The policy files are in `/var/cfengine/masterfiles` on the server (also known as the `policy_hub`) and are copied to `/var/cfengine/inputs`. All clients then copy `/var/cfengine/inputs` from the server.
+The policy files are distributed from `/var/cfengine/masterfiles` on the server (also known as the `policy_hub`). Clients copy policy files from `/var/cfengine/masterfiles` on the server to `/var/cfengine/inputs` on each local host, and run the policy out of `/var/cfengine/inputs`.
 
 <div style="text-align:center">![](policy_propagation.png)</div>
 
+Policy is cached locally in `/var/cfengine/inputs`. Clients can run CFEngine even when the server is unreachable, and update the cache opportunistically when they _can_ reach the server.
+
 Now edit the policy in `/var/cfengine/masterfiles` on the server and watch for the changes to happen on the client.
+
+# Adding Policies
 
 As you write new policies, each bundle needs to be listed in the `bundlesequence` and each file needs to be listed in `inputs`. Both of these are under `body common control` inside of `promises.cf`.
 

--- a/cf-primer.md
+++ b/cf-primer.md
@@ -580,7 +580,9 @@ You can use the server's IP address instead of the DNS name.
 
 # Distributing Policies
 
-The policy files are distributed from `/var/cfengine/masterfiles` on the server (also known as the `policy_hub`). Clients copy policy files from `/var/cfengine/masterfiles` on the server to `/var/cfengine/inputs` on each local host, and run the policy out of `/var/cfengine/inputs`.
+The policy files are distributed from `/var/cfengine/masterfiles` on the server (also known as the `policy_hub`).
+
+Clients copy policy files from `/var/cfengine/masterfiles` on the server to `/var/cfengine/inputs` on each host. CFEngine reads policy out of `/var/cfengine/inputs` when it runs (even on the server).
 
 <div style="text-align:center">![](policy_propagation.png)</div>
 

--- a/policy_propagation.dot
+++ b/policy_propagation.dot
@@ -5,7 +5,7 @@ digraph policy_propagation {
     h_masterfiles [ label = "/var/cfengine/masterfiles" color = blue style = filled fillcolor = white ]
     h_inputs [ label = "/var/cfengine/inputs" color = blue style = filled fillcolor = white ]
     h_masterfiles -> h_inputs;
-    label = "Policy Server";
+    label = "Server";
     style = filled;
   }
 

--- a/policy_propagation.dot
+++ b/policy_propagation.dot
@@ -5,33 +5,25 @@ digraph policy_propagation {
     h_masterfiles [ label = "/var/cfengine/masterfiles" color = blue style = filled fillcolor = white ]
     h_inputs [ label = "/var/cfengine/inputs" color = blue style = filled fillcolor = white ]
     h_masterfiles -> h_inputs;
-    label = "policy_hub";
+    label = "Policy Server";
     style = filled;
   }
-
-  // subgraph cluster_0b {
-    // c0b_inputs [ label = "/var/cfengine/inputs" color = blue style = filled fillcolor = white ]
-    // c0b_inputs;
-    // label = "policy_hub";
-    // style = filled;
-  // }
 
   subgraph cluster_1 {
     c1_inputs [ label = "/var/cfengine/inputs" color = blue style = filled fillcolor = white ]
     c1_inputs;
-    label = "client1";
+    label = "Client 1";
     style = filled;
   }
 
   subgraph cluster_2 {
     c2_inputs [ label = "/var/cfengine/inputs" color = blue style = filled fillcolor = white ]
     c2_inputs;
-    label = "client2";
+    label = "Client 2";
     style = filled;
   }
 
-  // h_masterfiles -> c0b_inputs;
-  h_inputs -> c1_inputs;
-  h_inputs -> c2_inputs;
+  h_masterfiles -> c1_inputs;
+  h_masterfiles -> c2_inputs;
 
 }


### PR DESCRIPTION
There has been some confusion about the policy distribution flow.  I've changed the diagram to emphasize that "masterfiles" is the (only) source point.

I've changed the text to split the "Managing and Distributing Policies" slide, so now we have one slide for "Distributing Policies", and I added some text (just a little) about how it works.  =)

Closes issue #5 